### PR TITLE
Add "jsxFragmentFactory" option to TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 		"allowSyntheticDefaultImports": true,
 		"jsx": "react",
 		"jsxFactory": "m",
+		"jsxFragmentFactory": "m.Fragment",
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"module": "CommonJS",
 		"moduleResolution": "node",


### PR DESCRIPTION
Hello,

I have created a pull request to add support for fragments in Mithril JS components, by adding the "jsxFragmentFactory" option to the TypeScript configuration file.

Fragments are a powerful feature in React and Mithril JS that allow developers to group multiple children without having to add an extra DOM element. The "jsxFragmentFactory" option specifies the function used for creating fragments in JSX. With this option, Mithril JS developers can now use fragments in their components without any additional setup.

Mithril JS supports both class-based and functional components. Here's an example of how to use fragments in a functional component:

```jsx
import * as m from "mithril";

function MyComponent() {
  return {
    view: () => {
      return (
        <>
          <p>This is some text.</p>
          <p>This is some more text.</p>
        </>
      )
    }
  };
}

export default MyComponent;
```

I would greatly appreciate it if you could review and merge this pull request if it meets your approval. Please let me know if you have any feedback or suggestions.

Thank you for your time and consideration.

Best regards,
Sofiane-77